### PR TITLE
Compatibility  sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Change <code>ApiUrl: '//example.net/'</code> in <code>www/config/environment.js<
     npm install -g ember-cli@2.9.1
     npm install -g bower
     npm install
-    bower install
+    bower install --allow-root
     ./build.sh
 
 Configure nginx to serve API on <code>/api</code> subdirectory.


### PR DESCRIPTION
root@ubuntu-2gb-sfo1-01:~/newpool/www# bower install
bower ESUDO         Cannot be run with sudo

Additional error details:
Since bower is a user command, there is no need to execute it with superuser permissions.
If you're having permission errors when using bower without sudo, please spend a few minutes learning more about how your system should work and make any necessary repairs.

http://www.joyent.com/blog/installing-node-and-npm
https://gist.github.com/isaacs/579814