### PR TITLE
ERORR PROXY

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
-## Open Source Ethereum Mining Pool
+## Open Source Whalecoin Mining Pool
 
-![Miner's stats page](https://15254b2dcaab7f5478ab-24461f391e20b7336331d5789078af53.ssl.cf1.rackcdn.com/ethereum.vanillaforums.com/editor/pe/cf77cki0pjpt.png)
+Forked from https://github.com/sammy007/open-ethereum-pool to account for the different mining reward payout in WhaleCoin compared to Ethereum.
 
-[![Join the chat at https://gitter.im/sammy007/open-ethereum-pool](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sammy007/open-ethereum-pool?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/sammy007/open-ethereum-pool.svg?branch=develop)](https://travis-ci.org/sammy007/open-ethereum-pool) [![Go Report Card](https://goreportcard.com/badge/github.com/sammy007/open-ethereum-pool)](https://goreportcard.com/report/github.com/sammy007/open-ethereum-pool)
-
-[List Of Open Ethereum Pools](https://github.com/sammy007/open-ethereum-pool/wiki/List-Of-Open-Pools)
 
 ### Features
 
@@ -19,7 +16,7 @@
 
 #### Proxies
 
-* [Ether-Proxy](https://github.com/sammy007/ether-proxy) HTTP proxy with web interface
+* [Ether-Proxy](https://github.com/WhaleCoinOrg/ether-proxy) HTTP proxy with web interface
 * [Stratum Proxy](https://github.com/Atrides/eth-proxy) for Ethereum
 
 ### Building on Linux
@@ -39,7 +36,7 @@ First install  [go-ethereum](https://github.com/ethereum/go-ethereum/wiki/Instal
 Clone & compile:
 
     git config --global http.https://gopkg.in.followRedirects true
-    git clone https://github.com/sammy007/open-ethereum-pool.git
+    git clone https://github.com/WhaleCoinOrg/open-ethereum-pool.git
     cd open-ethereum-pool
     make
 
@@ -311,7 +308,7 @@ This pool is tested to work with [Ethcore's Parity](https://github.com/ethcore/p
 
 ### Credits
 
-Made by sammy007. Licensed under GPLv3.
+Made by Sammy007. Licensed under GPLv3.
 
 #### Contributors
 

--- a/api/server.go
+++ b/api/server.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/sammy007/open-ethereum-pool/storage"
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/storage"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/util"
 )
 
 type ApiConfig struct {

--- a/build/env.sh
+++ b/build/env.sh
@@ -10,7 +10,7 @@ fi
 # Create fake Go workspace if it doesn't exist yet.
 workspace="$PWD/build/_workspace"
 root="$PWD"
-ethdir="$workspace/src/github.com/sammy007"
+ethdir="$workspace/src/github.com/WhaleCoinOrg"
 if [ ! -L "$ethdir/open-ethereum-pool" ]; then
     mkdir -p "$ethdir"
     cd "$ethdir"

--- a/main.go
+++ b/main.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/yvasiyarov/gorelic"
 
-	"github.com/sammy007/open-ethereum-pool/api"
-	"github.com/sammy007/open-ethereum-pool/payouts"
-	"github.com/sammy007/open-ethereum-pool/proxy"
-	"github.com/sammy007/open-ethereum-pool/storage"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/api"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/payouts"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/proxy"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/storage"
 )
 
 var cfg proxy.Config

--- a/payouts/payer.go
+++ b/payouts/payer.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/WhaleCoinOrg/WhaleCoin/common/hexutil"
 
 	"github.com/WhaleCoinOrg/open-ethereum-pool/rpc"
 	"github.com/WhaleCoinOrg/open-ethereum-pool/storage"

--- a/payouts/payer.go
+++ b/payouts/payer.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
-	"github.com/sammy007/open-ethereum-pool/rpc"
-	"github.com/sammy007/open-ethereum-pool/storage"
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/rpc"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/storage"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/util"
 )
 
 const txCheckInterval = 5 * time.Second

--- a/payouts/unlocker.go
+++ b/payouts/unlocker.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/math"
 
-	"github.com/sammy007/open-ethereum-pool/rpc"
-	"github.com/sammy007/open-ethereum-pool/storage"
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/rpc"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/storage"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/util"
 )
 
 type UnlockerConfig struct {

--- a/payouts/unlocker.go
+++ b/payouts/unlocker.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/WhaleCoinOrg/WhaleCoin/common/math"
 
 	"github.com/WhaleCoinOrg/open-ethereum-pool/rpc"
 	"github.com/WhaleCoinOrg/open-ethereum-pool/storage"
@@ -217,9 +217,9 @@ func (u *BlockUnlocker) handleBlock(block *rpc.GetBlockReply, candidate *storage
     reward := new(big.Int)
     headerRew := new(big.Int)
     headerRew.Div(block.Number, rewardBlockDivisor)
-    if (block.Number.Cmp(slowStart)  < 1 || block.Number.Cmp(slowStart)  == 0) {
+    if (block.Number.Cmp(slowStart)  == -1 || block.Number.Cmp(slowStart)  == 0) {
         reward = reward.Set(slowBlockReward)
-    } else if (block.Number.Cmp(rewardBlockFlat) > 1) {
+    } else if (block.Number.Cmp(rewardBlockFlat) == 1) {
         reward = reward.Set(finalBlockReward)
     } else {
     	headerRew.Mul(headerRew, slowBlockReward)
@@ -229,7 +229,7 @@ func (u *BlockUnlocker) handleBlock(block *rpc.GetBlockReply, candidate *storage
     rewardDivisor := big.NewInt(100)
     uncleReward := new(big.Int).Div(reward, new(big.Int).SetInt64(32))
     // if block.Number > 200000
-    if (block.Number.Cmp(rewardDistSwitchBlock) > 1) {
+    if (block.Number.Cmp(rewardDistSwitchBlock) == 1) {
     	uncleReward.Mul(uncleReward, rewardDistMinerPost)
     	uncleReward.Div(uncleReward, rewardDivisor)
 

--- a/payouts/unlocker_test.go
+++ b/payouts/unlocker_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/sammy007/open-ethereum-pool/rpc"
-	"github.com/sammy007/open-ethereum-pool/storage"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/rpc"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/storage"
 )
 
 func TestMain(m *testing.M) {

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -9,8 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/sammy007/open-ethereum-pool/storage"
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/storage"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/util"
 )
 
 type Config struct {

--- a/proxy/blocks.go
+++ b/proxy/blocks.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/sammy007/open-ethereum-pool/rpc"
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/rpc"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/util"
 )
 
 const maxBacklog = 3

--- a/proxy/blocks.go
+++ b/proxy/blocks.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/WhaleCoinOrg/WhaleCoin/common"
 
 	"github.com/WhaleCoinOrg/open-ethereum-pool/rpc"
 	"github.com/WhaleCoinOrg/open-ethereum-pool/util"

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -1,10 +1,10 @@
 package proxy
 
 import (
-	"github.com/sammy007/open-ethereum-pool/api"
-	"github.com/sammy007/open-ethereum-pool/payouts"
-	"github.com/sammy007/open-ethereum-pool/policy"
-	"github.com/sammy007/open-ethereum-pool/storage"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/api"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/payouts"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/policy"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/storage"
 )
 
 type Config struct {

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/sammy007/open-ethereum-pool/rpc"
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/rpc"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/util"
 )
 
 // Allow only lowercase hexadecimal with 0x prefix

--- a/proxy/miner.go
+++ b/proxy/miner.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/ethash"
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/WhaleCoinOrg/WhaleCoin/common"
 )
 
 var hasher = ethash.New()

--- a/proxy/miner.go
+++ b/proxy/miner.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ethereum/ethash"
+	"github.com/WhaleCoinOrg/WhaleCoin/ethash"
 	"github.com/WhaleCoinOrg/WhaleCoin/common"
 )
 

--- a/proxy/miner.go
+++ b/proxy/miner.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/WhaleCoinOrg/WhaleCoin/ethash"
+	"github.com/ethereum/ethash"
 	"github.com/WhaleCoinOrg/WhaleCoin/common"
 )
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/sammy007/open-ethereum-pool/policy"
-	"github.com/sammy007/open-ethereum-pool/rpc"
-	"github.com/sammy007/open-ethereum-pool/storage"
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/policy"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/rpc"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/storage"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/util"
 )
 
 type ProxyServer struct {

--- a/proxy/stratum.go
+++ b/proxy/stratum.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/util"
 )
 
 const (

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/util"
 )
 
 type RPCClient struct {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/WhaleCoinOrg/WhaleCoin/common"
 
 	"github.com/WhaleCoinOrg/open-ethereum-pool/util"
 )

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -9,7 +9,7 @@ import (
 
 	"gopkg.in/redis.v3"
 
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/WhaleCoinOrg/open-ethereum-pool/util"
 )
 
 type Config struct {

--- a/util/util.go
+++ b/util/util.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/WhaleCoinOrg/WhaleCoin/common"
+	"github.com/WhaleCoinOrg/WhaleCoin/common/math"
 )
 
 var Ether = math.BigPow(10, 18)

--- a/www/app/index.html
+++ b/www/app/index.html
@@ -24,7 +24,7 @@
     <footer class="footer">
       <div class="container">
         <p class="text-muted">&copy; CHANGEME in app/templates/index.html |
-          Powered by <a href="https://github.com/sammy007/open-ethereum-pool" target="_blank">open-ethereum-pool</a> |
+          Powered by <a href="https://github.com/WhaleCoinOrg/open-ethereum-pool" target="_blank">open-ethereum-pool</a> |
           <strong>Dev ETH/ETC:</strong>
           <a href="https://etherscan.io/address/0xb85150eb365e7df0941f0cf08235f987ba91506a" rel="nofollow" target="_blank">
             0xb85150eb365e7df0941f0cf08235f987ba91506a

--- a/www/app/templates/help.hbs
+++ b/www/app/templates/help.hbs
@@ -32,7 +32,7 @@
   <p class="lead">Edit <code>eth-proxy.conf</code> and specify our pool's <code>HOST: {{config.StratumHost}}</code>, <code>PORT: {{config.StratumPort}}</code> and your <code>WALLET</code>.</p>
 
   <h4>Mining with Ether-Proxy</h4>
-  <p class="lead">Use stable release of <a href="https://github.com/sammy007/ether-proxy/releases" target="_blank">Ethereum Solo/Pool Mining Proxy</a>.</p>
+  <p class="lead">Use stable release of <a href="https://github.com/WhaleCoinOrg/ether-proxy/releases" target="_blank">Ethereum Solo/Pool Mining Proxy</a>.</p>
 
   <h4>Advice</h4>
   <p>CPU mining is not recommended.</p>


### PR DESCRIPTION
github.com/WhaleCoinOrg/open-ethereum-pool/proxy
# github.com/WhaleCoinOrg/open-ethereum-pool/proxy
proxy/miner.go:44: cannot use share (type Block) as type ethash.Block in argument to hasher.Light.Verify:
        Block does not implement ethash.Block (wrong type for HashNoNonce method)
                have HashNoNonce() "github.com/WhaleCoinOrg/WhaleCoin/common".Hash
                want HashNoNonce() "github.com/ethereum/go-ethereum/common".Hash
proxy/miner.go:48: cannot use block (type Block) as type ethash.Block in argument to hasher.Light.Verify:
        Block does not implement ethash.Block (wrong type for HashNoNonce method)
                have HashNoNonce() "github.com/WhaleCoinOrg/WhaleCoin/common".Hash
                want HashNoNonce() "github.com/ethereum/go-ethereum/common".Hash
Makefile:10: recipe for target 'all' failed
make: *** [all] Error 2
