### PR TITLE
Update detection of successful transaction for byzantium

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -46,13 +46,13 @@ type GetBlockReplyPart struct {
 	Difficulty string `json:"difficulty"`
 }
 
-const receiptStatusSuccessful = "0x1"
+const receiptStatusSuccessful = 1
 
 type TxReceipt struct {
 	TxHash    string `json:"transactionHash"`
 	GasUsed   string `json:"gasUsed"`
 	BlockHash string `json:"blockHash"`
-	Status    string `json:"status"`
+	Status    int `json:"status"`
 }
 
 func (r *TxReceipt) Confirmed() bool {
@@ -61,10 +61,7 @@ func (r *TxReceipt) Confirmed() bool {
 
 // Use with previous method
 func (r *TxReceipt) Successful() bool {
-	if len(r.Status) > 0 {
 		return r.Status == receiptStatusSuccessful
-	}
-	return true
 }
 
 type Tx struct {


### PR DESCRIPTION
The field is returned as int and cannot be unmarshalled to string. The field can be either 0 (fail) or 1 (success).

More details: https://ethereum.stackexchange.com/questions/28077/how-do-i-detect-a-failed-transaction-after-the-byzantium-fork-as-the-revert-opco