### PR TITLE
Deploy pool on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.11
+
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY ./ /app
+
+RUN make
+
+CMD ./build/bin/open-ethereum-pool ./config.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: '2'
+services: 
+  proxy:
+    build: pool/open-ethereum-pool/
+    restart: always
+    ports:
+      - 3333:3333
+    volumes:
+      - ./proxy.json:/app/config.json
+    links:
+      - redis
+
+  api:
+    build: ./
+    restart: always
+    ports:
+      - 8181:8181
+    volumes:
+      - ./api.json:/app/config.json
+
+  unlocker:
+    build: pool/open-ethereum-pool/
+    restart: always
+    volumes:
+      - ./unlocker.json:/app/config.json
+
+  payouts:
+    build: pool/open-ethereum-pool/
+    restart: always
+    volumes:
+      - ./payouts.json:/app/config.json
+
+  web-builder:
+    build: www/
+    volumes:
+      - ./www-dist:/app/dist
+
+  web-development:
+    build: www/
+    volumes:
+      - ./www:/app
+    command: ember server --port 8082 --environment development
+
+  redis:
+    image: redis:latest
+    restart: always
+    ports:
+      - 6379:6379
+    volumes:
+      - redis:/data 
+    command: redis-server --appendonly yes
+
+volumes:
+  redis:

--- a/payouts/unlocker.go
+++ b/payouts/unlocker.go
@@ -30,9 +30,11 @@ type UnlockerConfig struct {
 
 const minDepth = 16
 const byzantiumHardForkHeight = 4370000
+const constantinopleHardForkHeight = 7280000
 
 var homesteadReward = math.MustParseBig256("5000000000000000000")
 var byzantiumReward = math.MustParseBig256("3000000000000000000")
+var constantinopleReward = math.MustParseBig256("2000000000000000000")
 
 // Donate 10% from pool fees to developers
 const donationFee = 10.0
@@ -502,6 +504,9 @@ func weiToShannonInt64(wei *big.Rat) int64 {
 }
 
 func getConstReward(height int64) *big.Int {
+	if height >= constantinopleHardForkHeight {
+		return new(big.Int).Set(constantinopleReward)
+	}
 	if height >= byzantiumHardForkHeight {
 		return new(big.Int).Set(byzantiumReward)
 	}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -239,6 +239,12 @@ func (r *RPCClient) doPost(url string, method string, params interface{}) (*JSON
 	data, _ := json.Marshal(jsonReq)
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+
+        if err != nil {
+                r.markSick()
+                return nil, err
+        }
+
 	req.Header.Set("Content-Length", (string)(len(data)))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")

--- a/www/Dockerfile
+++ b/www/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:11.1.0-alpine
+
+RUN apk add git
+
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY ./ /app
+
+VOLUME /app/www/dist
+
+RUN npm install -g ember-cli@2.9.1
+RUN npm install -g bower
+RUN npm install
+RUN bower --allow-root install
+
+CMD ./build.sh

--- a/www/build.sh
+++ b/www/build.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 ./node_modules/.bin/ember build --environment production


### PR DESCRIPTION
Add support for building and running pool as Docker containers. A `docker-compose.yml` file is included with all the needed separation of the pool processes.

There is another commit for some additional error logging on RPC connection creation in this PR. I can break it out of here if so desired.