### PR TITLE
Add support for TLS to stratum without breaking standard stratum

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,10 @@ otherwise you will get errors on start because of JSON comments.**
       // Bind stratum mining socket to this IP:PORT
       "listen": "0.0.0.0:8008",
       "timeout": "120s",
-      "maxConn": 8192
+      "maxConn": 8192,
+      "tls": false,
+      "certFile": "/path/to/cert.pem",
+      "keyFile": "/path/to/key.pem"
     },
 
     // Try to get new job from geth in this interval

--- a/config.example.json
+++ b/config.example.json
@@ -21,7 +21,10 @@
 			"enabled": true,
 			"listen": "0.0.0.0:8008",
 			"timeout": "120s",
-			"maxConn": 8192
+			"maxConn": 8192,
+			"tls": false,
+			"certFile": "/path/to/cert.pem",
+			"keyFile": "/path/to/key.pem"
 		},
 
 		"policy": {

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -48,10 +48,13 @@ type Proxy struct {
 }
 
 type Stratum struct {
-	Enabled bool   `json:"enabled"`
-	Listen  string `json:"listen"`
-	Timeout string `json:"timeout"`
-	MaxConn int    `json:"maxConn"`
+	Enabled  bool   `json:"enabled"`
+	Listen   string `json:"listen"`
+	Timeout  string `json:"timeout"`
+	MaxConn  int    `json:"maxConn"`
+	TLS      bool   `json:"tls"`
+	CertFile string `json:"certFile"`
+	KeyFile  string `json:"keyFile"`
 }
 
 type Upstream struct {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -42,7 +42,7 @@ type Session struct {
 
 	// Stratum
 	sync.Mutex
-	conn  *net.TCPConn
+	conn  net.Conn
 	login string
 }
 

--- a/proxy/stratum.go
+++ b/proxy/stratum.go
@@ -23,7 +23,8 @@ func (s *ProxyServer) ListenTCP() {
 	var err error
 	var server net.Listener
 	if s.config.Proxy.Stratum.TLS {
-		cert, err := tls.LoadX509KeyPair(s.config.Proxy.Stratum.CertFile, s.config.Proxy.Stratum.KeyFile)
+		var cert tls.Certificate
+		cert, err = tls.LoadX509KeyPair(s.config.Proxy.Stratum.CertFile, s.config.Proxy.Stratum.KeyFile)
 		if err != nil {
 			log.Fatalln("Error loading certificate:", err)
 		}

--- a/proxy/stratum.go
+++ b/proxy/stratum.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bufio"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"io"
@@ -17,14 +18,20 @@ const (
 )
 
 func (s *ProxyServer) ListenTCP() {
-	timeout := util.MustParseDuration(s.config.Proxy.Stratum.Timeout)
-	s.timeout = timeout
+	s.timeout = util.MustParseDuration(s.config.Proxy.Stratum.Timeout)
 
-	addr, err := net.ResolveTCPAddr("tcp", s.config.Proxy.Stratum.Listen)
-	if err != nil {
-		log.Fatalf("Error: %v", err)
+	var err error
+	var server net.Listener
+	if s.config.Proxy.Stratum.TLS {
+		cert, err := tls.LoadX509KeyPair(s.config.Proxy.Stratum.CertFile, s.config.Proxy.Stratum.KeyFile)
+		if err != nil {
+			log.Fatalln("Error loading certificate:", err)
+		}
+		tlsCfg := &tls.Config{Certificates: []tls.Certificate{cert}}
+		server, err = tls.Listen("tcp", s.config.Proxy.Stratum.Listen, tlsCfg)
+	} else {
+		server, err = net.Listen("tcp", s.config.Proxy.Stratum.Listen)
 	}
-	server, err := net.ListenTCP("tcp", addr)
 	if err != nil {
 		log.Fatalf("Error: %v", err)
 	}
@@ -35,12 +42,10 @@ func (s *ProxyServer) ListenTCP() {
 	n := 0
 
 	for {
-		conn, err := server.AcceptTCP()
+		conn, err := server.Accept()
 		if err != nil {
 			continue
 		}
-		conn.SetKeepAlive(true)
-
 		ip, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
 
 		if s.policy.IsBanned(ip) || !s.policy.ApplyLimitPolicy(ip) {
@@ -169,7 +174,7 @@ func (cs *Session) sendTCPError(id json.RawMessage, reply *ErrorReply) error {
 	return errors.New(reply.Message)
 }
 
-func (self *ProxyServer) setDeadline(conn *net.TCPConn) {
+func (self *ProxyServer) setDeadline(conn net.Conn) {
 	conn.SetDeadline(time.Now().Add(self.timeout))
 }
 

--- a/proxy/stratum.go
+++ b/proxy/stratum.go
@@ -22,6 +22,7 @@ func (s *ProxyServer) ListenTCP() {
 
 	var err error
 	var server net.Listener
+	setKeepAlive := func(net.Conn) {}
 	if s.config.Proxy.Stratum.TLS {
 		var cert tls.Certificate
 		cert, err = tls.LoadX509KeyPair(s.config.Proxy.Stratum.CertFile, s.config.Proxy.Stratum.KeyFile)
@@ -32,6 +33,9 @@ func (s *ProxyServer) ListenTCP() {
 		server, err = tls.Listen("tcp", s.config.Proxy.Stratum.Listen, tlsCfg)
 	} else {
 		server, err = net.Listen("tcp", s.config.Proxy.Stratum.Listen)
+		setKeepAlive = func(conn net.Conn) {
+			conn.(*net.TCPConn).SetKeepAlive(true)
+		}
 	}
 	if err != nil {
 		log.Fatalf("Error: %v", err)
@@ -47,6 +51,8 @@ func (s *ProxyServer) ListenTCP() {
 		if err != nil {
 			continue
 		}
+		setKeepAlive(conn)
+
 		ip, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
 
 		if s.policy.IsBanned(ip) || !s.policy.ApplyLimitPolicy(ip) {


### PR DESCRIPTION
This ports @sammy007 's original TLS support to the master branch.

The original patch breaks KeepAlive support for standard non-TLS stratums.  The fix for that is included in this PR.

Both standard HTTP and TLS stratums are running with this code on the pools at [wattpool.net](https://wattpool.net)