### PR TITLE
Fix KeepAlive on non TLS connections

### DIFF
--- a/proxy/stratum.go
+++ b/proxy/stratum.go
@@ -22,6 +22,7 @@ func (s *ProxyServer) ListenTCP() {
 
 	var err error
 	var server net.Listener
+	setKeepAlive := func(net.Conn) {}
 	if s.config.Proxy.Stratum.TLS {
 		var cert tls.Certificate
 		cert, err = tls.LoadX509KeyPair(s.config.Proxy.Stratum.CertFile, s.config.Proxy.Stratum.KeyFile)
@@ -32,6 +33,9 @@ func (s *ProxyServer) ListenTCP() {
 		server, err = tls.Listen("tcp", s.config.Proxy.Stratum.Listen, tlsCfg)
 	} else {
 		server, err = net.Listen("tcp", s.config.Proxy.Stratum.Listen)
+		setKeepAlive = func(conn net.Conn) {
+			conn.(*net.TCPConn).SetKeepAlive(true)
+		}
 	}
 	if err != nil {
 		log.Fatalf("Error: %v", err)
@@ -47,6 +51,8 @@ func (s *ProxyServer) ListenTCP() {
 		if err != nil {
 			continue
 		}
+		setKeepAlive(conn)
+
 		ip, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
 
 		if s.policy.IsBanned(ip) || !s.policy.ApplyLimitPolicy(ip) {


### PR DESCRIPTION
The current TLS support breaks KeepAlive support on standard non-tls stratum connections in the develop branch.  This fixes it.

Both standard HTTP and TLS stratums are running with this patch applied on the pools at [wattpool.net](https://wattpool.net) and [pool.egem.io](https://pool.egem.io)

see also #427 

cc: @btenterprise2020