### PR TITLE
Experimental: support geth `--miner.notify` option to push mining jobs

### DIFF
--- a/proxy/blocks.go
+++ b/proxy/blocks.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sammy007/open-ethereum-pool/util"
 )
 
-const maxBacklog = 3
+const maxBacklog = 10
 
 type heightDiffPair struct {
 	diff   *big.Int
@@ -60,8 +60,13 @@ func (s *ProxyServer) fetchBlockTemplate() {
 		return
 	}
 	// No need to update, we have fresh job
-	if t != nil && t.Header == reply[0] {
-		return
+	if t != nil {
+		if t.Header == reply[0] {
+			return
+		}
+		if _, ok := t.headers[reply[0]]; ok {
+			return
+		}
 	}
 
 	pendingReply.Difficulty = util.ToHex(s.config.Proxy.Difficulty)


### PR DESCRIPTION
***Experimental***

from geth v1.8.14, geth support `--miner.notify` option to push mining works.

this fix support notification feature of the latest geth.
for this case, `geth .... --miner.notify 127.0.0.1:8888/notify` option needed.